### PR TITLE
Add dynamic blog section to home page

### DIFF
--- a/blog-posts.js
+++ b/blog-posts.js
@@ -1,0 +1,75 @@
+/**
+ * Blog posts rendered on the home page.
+ *
+ * To add a new post, append an object to the array below. Only
+ * `title`, `url`, `excerpt`, `image`, and `date` are required;
+ * everything else is optional.
+ */
+window.blogPosts = [
+  {
+    title: 'Inside Tesla\'s carbon-sleeved motors',
+    url: '/blog/tesla-carbon-sleeve-motor-breakdown',
+    excerpt:
+      'We tore down the Model S Plaid\'s drive unit to understand how carbon overwrap, oil cooling, and hairpin windings unlock 1,000+ hp.',
+    image: 'https://images.unsplash.com/photo-1617786037733-006c4179e309?auto=format&fit=crop&w=1200&q=60',
+    alt: 'Electric motor rotor on a workbench',
+    category: 'Drivetrains',
+    date: 'January 4, 2024',
+    readTime: '11 min read'
+  },
+  {
+    title: 'Solid-state batteries: where the bottlenecks remain',
+    url: '/blog/solid-state-battery-bottlenecks',
+    excerpt:
+      'From sulfide electrolytes to stack pressure, here\'s the manufacturing math that keeps solid-state cells in pilot lines—for now.',
+    image: 'https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=1200&q=60',
+    alt: 'Lithium battery research lab',
+    category: 'Energy Storage',
+    date: 'December 14, 2023',
+    readTime: '9 min read'
+  },
+  {
+    title: 'The coming wave of megawatt charging depots',
+    url: '/blog/megawatt-charging-depots',
+    excerpt:
+      'Grid upgrades, cooling, and connector design for MCS sites that can fast charge Class 8 trucks without melting the cables.',
+    image: 'https://images.unsplash.com/photo-1615714276770-3f0232d9544d?auto=format&fit=crop&w=1200&q=60',
+    alt: 'Electric truck charging at an industrial depot',
+    category: 'Charging',
+    date: 'November 30, 2023',
+    readTime: '7 min read'
+  },
+  {
+    title: 'Software-defined vehicles need new E/E architectures',
+    url: '/blog/software-defined-vehicle-architecture',
+    excerpt:
+      'Domain controllers, zonal wiring, and gigabit Ethernet promise faster development cycles—if OEMs can retool their platforms.',
+    image: 'https://images.unsplash.com/photo-1582719478580-4ff2730ed3b7?auto=format&fit=crop&w=1200&q=60',
+    alt: 'Engineer reviewing automotive wiring diagrams',
+    category: 'Future Mobility',
+    date: 'November 8, 2023',
+    readTime: '8 min read'
+  },
+  {
+    title: 'Heat pump HVAC design for sub-zero efficiency',
+    url: '/blog/ev-heat-pump-hvac',
+    excerpt:
+      'Sizing vapor-injected compressors, valves, and refrigerants to hold cabin comfort without torching winter range.',
+    image: 'https://images.unsplash.com/photo-1607860108855-227bf51e96a0?auto=format&fit=crop&w=1200&q=60',
+    alt: 'EV HVAC system components on display',
+    category: 'Thermal Systems',
+    date: 'October 26, 2023',
+    readTime: '6 min read'
+  },
+  {
+    title: 'How inverter switching speeds impact NVH',
+    url: '/blog/inverter-switching-nvh',
+    excerpt:
+      'SiC MOSFETs switch faster, but that EMI and torque ripple can sneak into cabins—here\'s how OEMs damp it out.',
+    image: 'https://images.unsplash.com/photo-1580894906472-c4af2c56e8f2?auto=format&fit=crop&w=1200&q=60',
+    alt: 'Power electronics board with components',
+    category: 'Power Electronics',
+    date: 'October 5, 2023',
+    readTime: '10 min read'
+  }
+];

--- a/blog.js
+++ b/blog.js
@@ -1,0 +1,113 @@
+(function () {
+  // Render blog cards based on the data defined in blog-posts.js.
+  const grid = document.querySelector('[data-blog-grid]');
+  if (!grid) {
+    return;
+  }
+
+  const emptyState = document.querySelector('.blog-empty');
+  const posts = Array.isArray(window.blogPosts) ? window.blogPosts : [];
+  const maxItems = parseInt(grid.getAttribute('data-blog-max') || posts.length, 10);
+  const itemsToRender = posts.slice(0, isNaN(maxItems) ? posts.length : maxItems);
+
+  if (itemsToRender.length === 0) {
+    if (emptyState) {
+      emptyState.hidden = false;
+    }
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+
+  itemsToRender.forEach((post) => {
+    const article = document.createElement('article');
+    article.className = 'blog-card';
+
+    if (post.image) {
+      const imageLink = document.createElement('a');
+      imageLink.className = 'blog-card__image';
+      imageLink.href = post.url || '#';
+      applyLinkBehavior(imageLink, post);
+
+      const img = document.createElement('img');
+      img.src = post.image;
+      img.alt = post.alt || post.title || 'Blog post image';
+      imageLink.appendChild(img);
+      article.appendChild(imageLink);
+    }
+
+    const body = document.createElement('div');
+    body.className = 'blog-card__body';
+
+    if (post.category) {
+      const category = document.createElement('span');
+      category.className = 'blog-card__category';
+      category.textContent = post.category;
+      body.appendChild(category);
+    }
+
+    if (post.title) {
+      const title = document.createElement('h3');
+      const titleLink = document.createElement('a');
+      titleLink.className = 'blog-card__title';
+      titleLink.href = post.url || '#';
+      titleLink.textContent = post.title;
+      applyLinkBehavior(titleLink, post);
+      title.appendChild(titleLink);
+      body.appendChild(title);
+    }
+
+    if (post.excerpt) {
+      const excerpt = document.createElement('p');
+      excerpt.className = 'blog-card__excerpt';
+      excerpt.textContent = post.excerpt;
+      body.appendChild(excerpt);
+    }
+
+    const metaBits = [];
+    if (post.date) {
+      metaBits.push(post.date);
+    }
+    if (post.readTime) {
+      metaBits.push(post.readTime);
+    }
+    if (post.author) {
+      metaBits.push(post.author);
+    }
+
+    if (metaBits.length > 0) {
+      const meta = document.createElement('div');
+      meta.className = 'blog-card__meta';
+      meta.textContent = metaBits.join(' • ');
+      body.appendChild(meta);
+    }
+
+    article.appendChild(body);
+    fragment.appendChild(article);
+  });
+
+  grid.appendChild(fragment);
+
+  function applyLinkBehavior(link, post) {
+    if (!link || !post) {
+      return;
+    }
+
+    let relValue = '';
+
+    if (post.external || post.target === '_blank') {
+      link.target = '_blank';
+      relValue = 'noopener';
+    } else if (post.target) {
+      link.target = post.target;
+    }
+
+    if (post.rel) {
+      relValue = relValue ? relValue + ' ' + post.rel : post.rel;
+    }
+
+    if (relValue) {
+      link.rel = relValue;
+    }
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -37,11 +37,29 @@
     .card .pad{padding:16px;}
     .pill{font-size:12px;border:1px solid rgba(0,0,0,.1);padding:4px 8px;border-radius:999px;display:inline-block;margin-bottom:8px;}
     .two-col{display:grid;grid-template-columns:1.2fr .8fr;gap:36px;align-items:center;}
+    .blog-header{display:flex;justify-content:space-between;gap:24px;align-items:flex-start;flex-wrap:wrap;}
+    .blog-header p{max-width:640px;}
+    .blog-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:28px;margin-top:32px;}
+    .blog-card{border:1px solid rgba(8,10,69,.08);border-radius:16px;overflow:hidden;background:#fff;display:flex;flex-direction:column;box-shadow:0 12px 32px rgba(13,15,70,.08);transition:transform .25s ease, box-shadow .25s ease;}
+    .blog-card:hover{transform:translateY(-4px);box-shadow:0 18px 40px rgba(13,15,70,.12);}
+    .blog-card__image{display:block;position:relative;}
+    .blog-card__image img{width:100%;height:100%;object-fit:cover;aspect-ratio:16/9;display:block;}
+    .blog-card__body{padding:20px 22px 24px;display:flex;flex-direction:column;gap:12px;}
+    .blog-card__body h3{margin:0;}
+    .blog-card__body p{margin:0;}
+    .blog-card__category{font-size:13px;text-transform:uppercase;letter-spacing:.08em;font-weight:600;display:inline-flex;align-items:center;gap:8px;color:var(--dl-color-theme-primary1);}
+    .blog-card__category::before{content:'';width:8px;height:8px;border-radius:999px;background:linear-gradient(135deg,#00C4FF,#0051FF);display:inline-block;}
+    .blog-card__title{font-family:Bricolage Grotesque;font-size:24px;font-weight:700;line-height:1.3;text-decoration:none;color:inherit;}
+    .blog-card__title:hover{text-decoration:underline;}
+    .blog-card__excerpt{font-size:16px;line-height:1.55;opacity:.85;}
+    .blog-card__meta{font-size:14px;opacity:.7;display:flex;gap:12px;align-items:center;flex-wrap:wrap;}
+    .blog-empty{margin-top:24px;font-size:18px;opacity:.8;}
     .footer{margin-top:auto;background:#0b0f3f;color:white;}
     .footer a{color:#C5B6E0;text-decoration:none;}
     .footer .container{padding-top:var(--dl-layout-space-threeunits);padding-bottom:var(--dl-layout-space-threeunits);}
-    @media(max-width: 991px){ .grid{grid-template-columns:repeat(2,1fr)} .two-col{grid-template-columns:1fr} .hero h1{font-size:44px;} }
-    @media(max-width: 599px){ .grid{grid-template-columns:1fr} .hero h1{font-size:36px;} .nav-links{display:none;} }
+    @media(max-width: 1200px){ .blog-grid{grid-template-columns:repeat(2,1fr);} }
+    @media(max-width: 991px){ .grid{grid-template-columns:repeat(2,1fr)} .two-col{grid-template-columns:1fr} .hero h1{font-size:44px;} .blog-grid{grid-template-columns:repeat(2,1fr);} }
+    @media(max-width: 599px){ .grid{grid-template-columns:1fr} .hero h1{font-size:36px;} .nav-links{display:none;} .blog-grid{grid-template-columns:1fr;} }
   </style>
 </head>
 <body>
@@ -55,6 +73,7 @@
       </a>
       <nav class="nav-links thq-body-small">
         <a href="#videos" class="thq-link">Videos</a>
+        <a href="#blog" class="thq-link">Blog</a>
         <a href="#explainers" class="thq-link">Tech Explainers</a>
         <a href="#mobility" class="thq-link">Future Mobility</a>
         <a href="#resources" class="thq-link">Resources</a>
@@ -106,6 +125,21 @@
           </div>
         </a>
       </div>
+    </div>
+  </section>
+
+  <!-- BLOG -->
+  <section id="blog">
+    <div class="container">
+      <div class="blog-header">
+        <div>
+          <h2 class="thq-heading-2">From the blog</h2>
+          <p class="thq-body-large">In-depth explainers and teardown notes on EV drivetrains, energy storage, charging infrastructure, and mobility business models.</p>
+        </div>
+        <a class="thq-button-outline" href="/blog" aria-label="View all blog posts">View all posts</a>
+      </div>
+      <div class="blog-grid" data-blog-grid data-blog-max="6"></div>
+      <p class="blog-empty thq-body-large" hidden>No blog posts yet—check back soon.</p>
     </div>
   </section>
 
@@ -205,5 +239,7 @@
   </footer>
 </div>
 <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+<script src="./blog-posts.js"></script>
+<script src="./blog.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a dedicated blog section to the landing page with responsive styling and navigation
- render blog cards dynamically from a reusable data source with an empty-state fallback
- seed the blog data file with example posts to make future additions copy-and-paste simple

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cf177df414832b854acc88ea42b3c2